### PR TITLE
Error state logic

### DIFF
--- a/Example/OTPTextFieldExample.xcodeproj/project.pbxproj
+++ b/Example/OTPTextFieldExample.xcodeproj/project.pbxproj
@@ -9,15 +9,20 @@
 /* Begin PBXBuildFile section */
 		001EBC7F44EC7BDB090F32C3 /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1235D35CF71609F099221E45 /* MainCoordinator.swift */; };
 		180D168CE1B8D4130F477FF8 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1902184A5B42D3BE892DAB51 /* MainViewController.swift */; };
+		18310A80F4B9D67A5E1084D0 /* PlainOtpFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C2FA792A43B4CC3BF741FE /* PlainOtpFieldViewController.swift */; };
 		27AA807C83CA4084E66AA9D4 /* CustomOtpFieldPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CEEEB4D6AC97D711A6195A /* CustomOtpFieldPresenter.swift */; };
 		2D459EBDD8DD0A26C3EDA746 /* DefaultOtpFieldViewInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF50A6EC8E2439317848F018 /* DefaultOtpFieldViewInput.swift */; };
+		2F561E3FC523251AEC26E157 /* PlainOtpFieldModuleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1014A51D083D3AB6AD3BF75D /* PlainOtpFieldModuleInput.swift */; };
 		35D4C539CD12B28C9A1FC7E8 /* CustomOtpFieldModuleConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663406EB5B5D8317D4ABD9E9 /* CustomOtpFieldModuleConfigurator.swift */; };
+		38C51C20BD69A49CAE73FC0C /* PlainOtpFieldModuleOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F4D64632E6041C75A5BBFE /* PlainOtpFieldModuleOutput.swift */; };
 		3A6087EA2DA78E246EA1FF3F /* DefaultOtpFieldModuleConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991AB6889B70466D5CCFA447 /* DefaultOtpFieldModuleConfigurator.swift */; };
 		3BB5B81EA6EB621E1A2860C3 /* DefaultOtpFieldModuleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013050DC37F4A9A747D0CB92 /* DefaultOtpFieldModuleInput.swift */; };
 		3CF50EEB7FB8EDF784F4DCA4 /* MainModuleConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB20CA3DCDF11B6580BDFDD3 /* MainModuleConfigurator.swift */; };
 		40F0977EBC72C8BB52B69963 /* MainModuleOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E711291C3F0B6B2B5128571 /* MainModuleOutput.swift */; };
 		43B2697ACDDF66A9A92D78EF /* RoundOtpFieldViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AADF29673AE68CF2B7014090 /* RoundOtpFieldViewController.xib */; };
 		46502BFD64D31DCD91B09FE1 /* CustomOtpFieldModuleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42B207DF58327A76B14E9B1 /* CustomOtpFieldModuleInput.swift */; };
+		4FCDC7A6BDE3DBACB445E682 /* PlainOtpFieldViewInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D7EE9AC2B657A504C76C7 /* PlainOtpFieldViewInput.swift */; };
+		5349567F9BE25FAE9B4B8D78 /* PlainOtpFieldPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03B7B834BDE8E71B3689038 /* PlainOtpFieldPresenter.swift */; };
 		57A3C5042424C24200AB0219 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57A3C5032424C24200AB0219 /* LaunchScreen.xib */; };
 		57A3C5062424C24200AB0219 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57A3C5052424C24200AB0219 /* Assets.xcassets */; };
 		57A3C5082424C24200AB0219 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A3C5072424C24200AB0219 /* AppDelegate.swift */; };
@@ -48,8 +53,12 @@
 		72482672A5B450642912F030 /* DefaultOtpFieldModuleOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A00833A6B8BFBC14278A5 /* DefaultOtpFieldModuleOutput.swift */; };
 		81B101CD5EF4CB190873C808 /* CustomOtpFieldViewOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8252E87584CA68DEF611B5D /* CustomOtpFieldViewOutput.swift */; };
 		833C6A87AB0AB446DB2EB3C5 /* CustomOtpFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29781F0D482F543CA9AD8289 /* CustomOtpFieldViewController.swift */; };
+		88C0B157A790F0C3F0BCE49C /* PlainOtpFieldModuleConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62B5AC4FAC54D30BB90BFC /* PlainOtpFieldModuleConfigurator.swift */; };
 		8F3EEC6313FFB239DF818EBF /* MainPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614ADB3A4C81BA429FD7787D /* MainPresenter.swift */; };
 		8FEBC87D02C3174AB77DDB2F /* DefaultOtpFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05466F945EB81009602C58 /* DefaultOtpFieldViewController.swift */; };
+		90C77D0C24CC7EC400992FB1 /* PlainOTPFieldAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C77D0B24CC7EC400992FB1 /* PlainOTPFieldAdapter.swift */; };
+		90C77D0F24CC7ED800992FB1 /* PlainPinView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C77D0E24CC7ED800992FB1 /* PlainPinView.swift */; };
+		90C77D1124CC7EE000992FB1 /* PlainPinView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 90C77D1024CC7EE000992FB1 /* PlainPinView.xib */; };
 		91146BECA3B9CFBF175DE150 /* MainViewInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = F249167611841325E6EC8C2C /* MainViewInput.swift */; };
 		976B5C0B1566BB6782850930 /* DefaultOtpFieldViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 061EA15C38C9EDA1CE279C86 /* DefaultOtpFieldViewController.xib */; };
 		9C648A4F8548454B9FE4CAB5 /* RoundOtpFieldPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1DBA564130BD0BFF71D428 /* RoundOtpFieldPresenter.swift */; };
@@ -61,6 +70,8 @@
 		CBC6D9B25EDE3819AC5BD595 /* CustomOtpFieldViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 50858B0356027E863913E0C8 /* CustomOtpFieldViewController.xib */; };
 		D1D05B03DF366920C8F0FBA0 /* MainModuleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808CBF6C8958F8703053E6A0 /* MainModuleInput.swift */; };
 		D5A03890F6B9FAD936A09DC1 /* RoundOtpFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A8DC00DF40FAEBD9C3E954 /* RoundOtpFieldViewController.swift */; };
+		D780ACF2B316CB7B4AF93098 /* PlainOtpFieldViewOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4A108388384E1580AD9301 /* PlainOtpFieldViewOutput.swift */; };
+		D9D8F8600FDEC30E5F3C75CC /* PlainOtpFieldViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C04E33050E65433348DD7B2B /* PlainOtpFieldViewController.xib */; };
 		E445DA4B607394CFB2E1B2C8 /* DefaultOtpFieldViewOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B7ACAE5BA796C9B2AAEF07 /* DefaultOtpFieldViewOutput.swift */; };
 		E4D2CCCFB823793CDD940791 /* RoundOtpFieldModuleConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8116BFCB5EA3BE34D2F55FA /* RoundOtpFieldModuleConfigurator.swift */; };
 		E691FF674C33DF091FAB19E1 /* MainViewOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07B136FE44FD52426999952 /* MainViewOutput.swift */; };
@@ -73,6 +84,7 @@
 		0BC83CFFADF8632C5AC45AE4 /* RoundOtpFieldViewOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RoundOtpFieldViewOutput.swift; sourceTree = "<group>"; };
 		0D4C4C5327893CCA644C90B7 /* Pods-OTPTextFieldExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OTPTextFieldExample.debug.xcconfig"; path = "Target Support Files/Pods-OTPTextFieldExample/Pods-OTPTextFieldExample.debug.xcconfig"; sourceTree = "<group>"; };
 		0E711291C3F0B6B2B5128571 /* MainModuleOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainModuleOutput.swift; sourceTree = "<group>"; };
+		1014A51D083D3AB6AD3BF75D /* PlainOtpFieldModuleInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlainOtpFieldModuleInput.swift; sourceTree = "<group>"; };
 		1235D35CF71609F099221E45 /* MainCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		1346AF16632293DF38468624 /* CustomOtpFieldViewInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomOtpFieldViewInput.swift; sourceTree = "<group>"; };
 		1902184A5B42D3BE892DAB51 /* MainViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -117,12 +129,18 @@
 		57A3C5462425281900AB0219 /* CustomFieldAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldAdapter.swift; sourceTree = "<group>"; };
 		614ADB3A4C81BA429FD7787D /* MainPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainPresenter.swift; sourceTree = "<group>"; };
 		63A8DC00DF40FAEBD9C3E954 /* RoundOtpFieldViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RoundOtpFieldViewController.swift; sourceTree = "<group>"; };
+		65F4D64632E6041C75A5BBFE /* PlainOtpFieldModuleOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlainOtpFieldModuleOutput.swift; sourceTree = "<group>"; };
 		663406EB5B5D8317D4ABD9E9 /* CustomOtpFieldModuleConfigurator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomOtpFieldModuleConfigurator.swift; sourceTree = "<group>"; };
 		68F0DBF8FF2865F3224162A3 /* RoundOtpFieldModuleInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RoundOtpFieldModuleInput.swift; sourceTree = "<group>"; };
+		6F62B5AC4FAC54D30BB90BFC /* PlainOtpFieldModuleConfigurator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlainOtpFieldModuleConfigurator.swift; sourceTree = "<group>"; };
 		72D67F0A790D343C4BD742CD /* CustomOtpFieldModuleOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomOtpFieldModuleOutput.swift; sourceTree = "<group>"; };
+		7C4A108388384E1580AD9301 /* PlainOtpFieldViewOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlainOtpFieldViewOutput.swift; sourceTree = "<group>"; };
 		7D1DBA564130BD0BFF71D428 /* RoundOtpFieldPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RoundOtpFieldPresenter.swift; sourceTree = "<group>"; };
 		808CBF6C8958F8703053E6A0 /* MainModuleInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainModuleInput.swift; sourceTree = "<group>"; };
 		887A00833A6B8BFBC14278A5 /* DefaultOtpFieldModuleOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultOtpFieldModuleOutput.swift; sourceTree = "<group>"; };
+		90C77D0B24CC7EC400992FB1 /* PlainOTPFieldAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainOTPFieldAdapter.swift; sourceTree = "<group>"; };
+		90C77D0E24CC7ED800992FB1 /* PlainPinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainPinView.swift; sourceTree = "<group>"; };
+		90C77D1024CC7EE000992FB1 /* PlainPinView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PlainPinView.xib; sourceTree = "<group>"; };
 		93965E3F6DEB41B4575D462B /* DefaultOtpFieldPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultOtpFieldPresenter.swift; sourceTree = "<group>"; };
 		971FAE21CFA4F4CF77C84DD3 /* Pods-OTPTextFieldExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OTPTextFieldExample.release.xcconfig"; path = "Target Support Files/Pods-OTPTextFieldExample/Pods-OTPTextFieldExample.release.xcconfig"; sourceTree = "<group>"; };
 		991AB6889B70466D5CCFA447 /* DefaultOtpFieldModuleConfigurator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultOtpFieldModuleConfigurator.swift; sourceTree = "<group>"; };
@@ -130,8 +148,12 @@
 		AB20CA3DCDF11B6580BDFDD3 /* MainModuleConfigurator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainModuleConfigurator.swift; sourceTree = "<group>"; };
 		AF50A6EC8E2439317848F018 /* DefaultOtpFieldViewInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultOtpFieldViewInput.swift; sourceTree = "<group>"; };
 		B07B136FE44FD52426999952 /* MainViewOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainViewOutput.swift; sourceTree = "<group>"; };
+		B0C2FA792A43B4CC3BF741FE /* PlainOtpFieldViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlainOtpFieldViewController.swift; sourceTree = "<group>"; };
 		B42B207DF58327A76B14E9B1 /* CustomOtpFieldModuleInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomOtpFieldModuleInput.swift; sourceTree = "<group>"; };
 		B8252E87584CA68DEF611B5D /* CustomOtpFieldViewOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomOtpFieldViewOutput.swift; sourceTree = "<group>"; };
+		C03B7B834BDE8E71B3689038 /* PlainOtpFieldPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlainOtpFieldPresenter.swift; sourceTree = "<group>"; };
+		C04E33050E65433348DD7B2B /* PlainOtpFieldViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = PlainOtpFieldViewController.xib; sourceTree = "<group>"; };
+		CB6D7EE9AC2B657A504C76C7 /* PlainOtpFieldViewInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlainOtpFieldViewInput.swift; sourceTree = "<group>"; };
 		D0491F7553925E0D85199469 /* MainCoordinatorOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainCoordinatorOutput.swift; sourceTree = "<group>"; };
 		E8116BFCB5EA3BE34D2F55FA /* RoundOtpFieldModuleConfigurator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RoundOtpFieldModuleConfigurator.swift; sourceTree = "<group>"; };
 		F249167611841325E6EC8C2C /* MainViewInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainViewInput.swift; sourceTree = "<group>"; };
@@ -218,6 +240,16 @@
 				B8252E87584CA68DEF611B5D /* CustomOtpFieldViewOutput.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		484EC55D7AE20A51E9EAD852 /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				C03B7B834BDE8E71B3689038 /* PlainOtpFieldPresenter.swift */,
+				1014A51D083D3AB6AD3BF75D /* PlainOtpFieldModuleInput.swift */,
+				65F4D64632E6041C75A5BBFE /* PlainOtpFieldModuleOutput.swift */,
+			);
+			path = Presenter;
 			sourceTree = "<group>";
 		};
 		5336BD0683B487E497BA0751 /* Configurator */ = {
@@ -460,6 +492,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		744F2026C338B3A5C338C697 /* Configurator */ = {
+			isa = PBXGroup;
+			children = (
+				6F62B5AC4FAC54D30BB90BFC /* PlainOtpFieldModuleConfigurator.swift */,
+			);
+			path = Configurator;
+			sourceTree = "<group>";
+		};
 		8D3FA10E9A10213A97F24872 /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
@@ -468,6 +508,24 @@
 				0E711291C3F0B6B2B5128571 /* MainModuleOutput.swift */,
 			);
 			path = Presenter;
+			sourceTree = "<group>";
+		};
+		90C77D0A24CC7EAE00992FB1 /* PlainOTPField */ = {
+			isa = PBXGroup;
+			children = (
+				90C77D0D24CC7ECA00992FB1 /* PlainPinView */,
+				90C77D0B24CC7EC400992FB1 /* PlainOTPFieldAdapter.swift */,
+			);
+			path = PlainOTPField;
+			sourceTree = "<group>";
+		};
+		90C77D0D24CC7ECA00992FB1 /* PlainPinView */ = {
+			isa = PBXGroup;
+			children = (
+				90C77D0E24CC7ED800992FB1 /* PlainPinView.swift */,
+				90C77D1024CC7EE000992FB1 /* PlainPinView.xib */,
+			);
+			path = PlainPinView;
 			sourceTree = "<group>";
 		};
 		A96C53A3E9593A37A5F28639 /* Main */ = {
@@ -489,8 +547,19 @@
 				BE3E3B97887C20FDD0908D30 /* DefaultOtpField */,
 				E1D0933759E6C245FF2FA945 /* RoundOtpField */,
 				069FFC1332D5C30B4F58AFA7 /* CustomOtpField */,
+				BA2911B402CB2285BAF4CD73 /* PlainOtpField */,
 			);
 			path = Main;
+			sourceTree = "<group>";
+		};
+		BA2911B402CB2285BAF4CD73 /* PlainOtpField */ = {
+			isa = PBXGroup;
+			children = (
+				744F2026C338B3A5C338C697 /* Configurator */,
+				484EC55D7AE20A51E9EAD852 /* Presenter */,
+				F9285F88C1F480E6E284B586 /* View */,
+			);
+			path = PlainOtpField;
 			sourceTree = "<group>";
 		};
 		BE3E3B97887C20FDD0908D30 /* DefaultOtpField */ = {
@@ -548,6 +617,18 @@
 				AADF29673AE68CF2B7014090 /* RoundOtpFieldViewController.xib */,
 				2F7E12AB4F34BD070E8CEA49 /* RoundOtpFieldViewInput.swift */,
 				0BC83CFFADF8632C5AC45AE4 /* RoundOtpFieldViewOutput.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		F9285F88C1F480E6E284B586 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				90C77D0A24CC7EAE00992FB1 /* PlainOTPField */,
+				B0C2FA792A43B4CC3BF741FE /* PlainOtpFieldViewController.swift */,
+				C04E33050E65433348DD7B2B /* PlainOtpFieldViewController.xib */,
+				CB6D7EE9AC2B657A504C76C7 /* PlainOtpFieldViewInput.swift */,
+				7C4A108388384E1580AD9301 /* PlainOtpFieldViewOutput.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -623,6 +704,8 @@
 				976B5C0B1566BB6782850930 /* DefaultOtpFieldViewController.xib in Resources */,
 				43B2697ACDDF66A9A92D78EF /* RoundOtpFieldViewController.xib in Resources */,
 				CBC6D9B25EDE3819AC5BD595 /* CustomOtpFieldViewController.xib in Resources */,
+				D9D8F8600FDEC30E5F3C75CC /* PlainOtpFieldViewController.xib in Resources */,
+				90C77D1124CC7EE000992FB1 /* PlainPinView.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -712,6 +795,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				57A3C5232424C24200AB0219 /* Coordinator.swift in Sources */,
+				90C77D0C24CC7EC400992FB1 /* PlainOTPFieldAdapter.swift in Sources */,
 				57A3C50E2424C24200AB0219 /* Assets.swift in Sources */,
 				57A3C5272424C24200AB0219 /* Router.swift in Sources */,
 				57A3C53A2424DA4E00AB0219 /* DefaultNavigationController.swift in Sources */,
@@ -750,6 +834,7 @@
 				66523596D246DA6649612683 /* RoundOtpFieldModuleInput.swift in Sources */,
 				F3084921EFEA474E604D1F45 /* RoundOtpFieldModuleOutput.swift in Sources */,
 				D5A03890F6B9FAD936A09DC1 /* RoundOtpFieldViewController.swift in Sources */,
+				90C77D0F24CC7ED800992FB1 /* PlainPinView.swift in Sources */,
 				CAC3D298694BD31552046405 /* RoundOtpFieldViewInput.swift in Sources */,
 				C21262617191C7E963148455 /* RoundOtpFieldViewOutput.swift in Sources */,
 				35D4C539CD12B28C9A1FC7E8 /* CustomOtpFieldModuleConfigurator.swift in Sources */,
@@ -759,6 +844,13 @@
 				833C6A87AB0AB446DB2EB3C5 /* CustomOtpFieldViewController.swift in Sources */,
 				A6EFB03D812116945EAB749B /* CustomOtpFieldViewInput.swift in Sources */,
 				81B101CD5EF4CB190873C808 /* CustomOtpFieldViewOutput.swift in Sources */,
+				88C0B157A790F0C3F0BCE49C /* PlainOtpFieldModuleConfigurator.swift in Sources */,
+				5349567F9BE25FAE9B4B8D78 /* PlainOtpFieldPresenter.swift in Sources */,
+				2F561E3FC523251AEC26E157 /* PlainOtpFieldModuleInput.swift in Sources */,
+				38C51C20BD69A49CAE73FC0C /* PlainOtpFieldModuleOutput.swift in Sources */,
+				18310A80F4B9D67A5E1084D0 /* PlainOtpFieldViewController.swift in Sources */,
+				4FCDC7A6BDE3DBACB445E682 /* PlainOtpFieldViewInput.swift in Sources */,
+				D780ACF2B316CB7B4AF93098 /* PlainOtpFieldViewOutput.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomFieldAdapter.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomFieldAdapter.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import OTPTextField
+import SFOTPTextField
 import SurfUtils
 
 final class CustomFieldAdapter: NSObject {

--- a/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomPinView/CustomPinView.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomPinView/CustomPinView.swift
@@ -38,10 +38,10 @@ extension CustomPinView: PinContainer {
     }
 
     func setupState(isActive: Bool, isError: Bool) {
-        if isActive {
-            indicatorView.backgroundColor = Colors.Figma.defaultBlue
+        if isError {
+            indicatorView.backgroundColor = Colors.Figma.defaultRed
         } else {
-            let color = isError ? Colors.Figma.defaultRed : Colors.Figma.negativeBackground
+            let color = isActive ? Colors.Figma.defaultBlue : Colors.Figma.negativeBackground
             indicatorView.backgroundColor = color
         }
     }

--- a/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomPinView/CustomPinView.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomPinView/CustomPinView.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import OTPTextField
+import SFOTPTextField
 
 final class CustomPinView: UIView {
 

--- a/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomPinView/CustomPinView.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOTPField/CustomPinView/CustomPinView.swift
@@ -33,24 +33,17 @@ extension CustomPinView: PinContainer {
         codeLabel.text = value
     }
 
-    func setError() {
-        indicatorView.backgroundColor = Colors.Figma.defaultRed
-    }
-
-    func removeError() {
-        indicatorView.backgroundColor = Colors.Figma.negativeBackground
-    }
-
     func clear() {
         codeLabel.text = nil
     }
 
-    func animateIndicator() {
-        indicatorView.backgroundColor = Colors.Figma.defaultBlue
-    }
-
-    func removeIndicator() {
-        indicatorView.backgroundColor = Colors.Figma.negativeBackground
+    func setupState(isActive: Bool, isError: Bool) {
+        if isActive {
+            indicatorView.backgroundColor = Colors.Figma.defaultBlue
+        } else {
+            let color = isError ? Colors.Figma.defaultRed : Colors.Figma.negativeBackground
+            indicatorView.backgroundColor = color
+        }
     }
 
 }

--- a/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOtpFieldViewController.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOtpFieldViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import OTPTextField
+import SFOTPTextField
 
 final class CustomOtpFieldViewController: UIViewController {
 

--- a/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOtpFieldViewController.xib
+++ b/Example/OTPTextFieldExample/Flows/Main/CustomOtpField/View/CustomOtpFieldViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ECo-qT-RDB" customClass="OTPTextField" customModule="OTPTextField">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ECo-qT-RDB" customClass="OTPTextField" customModule="SFOTPTextField">
                     <rect key="frame" x="65" y="69" width="190" height="62"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>

--- a/Example/OTPTextFieldExample/Flows/Main/DefaultOtpField/View/DefaultOtpFieldViewController.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/DefaultOtpField/View/DefaultOtpFieldViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import OTPTextField
+import SFOTPTextField
 
 final class DefaultOtpFieldViewController: UIViewController {
 

--- a/Example/OTPTextFieldExample/Flows/Main/DefaultOtpField/View/DefaultOtpFieldViewController.xib
+++ b/Example/OTPTextFieldExample/Flows/Main/DefaultOtpField/View/DefaultOtpFieldViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,7 +27,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bcN-dQ-BM9" customClass="OTPTextField" customModule="OTPTextField">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bcN-dQ-BM9" customClass="OTPTextField" customModule="SFOTPTextField">
                     <rect key="frame" x="24" y="65" width="272" height="48"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>

--- a/Example/OTPTextFieldExample/Flows/Main/MainCoordinator.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/MainCoordinator.swift
@@ -49,6 +49,11 @@ private extension MainCoordinator {
         router.push(view)
     }
 
+    func showPlainOtpField() {
+        let (view, _) = PlainOtpFieldModuleConfigurator().configure()
+        router.push(view)
+    }
+
 }
 
 // MARK: - Help Methods
@@ -63,6 +68,8 @@ private extension MainCoordinator {
             showRoundOtpScreen()
         case .custom:
             showCustomOtpField()
+        case .plain:
+            showPlainOtpField()
         }
     }
 

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Configurator/PlainOtpFieldModuleConfigurator.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Configurator/PlainOtpFieldModuleConfigurator.swift
@@ -1,0 +1,23 @@
+//
+//  PlainOtpFieldModuleConfigurator.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+import UIKit
+
+final class PlainOtpFieldModuleConfigurator {
+
+    func configure() -> (UIViewController, PlainOtpFieldModuleOutput) {
+        let view = PlainOtpFieldViewController()
+        let presenter = PlainOtpFieldPresenter()
+
+        presenter.view = view
+        view.output = presenter
+
+        return (view, presenter)
+    }
+
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Presenter/PlainOtpFieldModuleInput.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Presenter/PlainOtpFieldModuleInput.swift
@@ -1,0 +1,10 @@
+//
+//  PlainOtpFieldModuleInput.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+protocol PlainOtpFieldModuleInput: class {
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Presenter/PlainOtpFieldModuleOutput.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Presenter/PlainOtpFieldModuleOutput.swift
@@ -1,0 +1,10 @@
+//
+//  PlainOtpFieldModuleOutput.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+protocol PlainOtpFieldModuleOutput: class {
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Presenter/PlainOtpFieldPresenter.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/Presenter/PlainOtpFieldPresenter.swift
@@ -1,0 +1,32 @@
+//
+//  PlainOtpFieldPresenter.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+final class PlainOtpFieldPresenter: PlainOtpFieldModuleOutput {
+
+    // MARK: - PlainOtpFieldModuleOutput
+
+    // MARK: - Properties
+
+    weak var view: PlainOtpFieldViewInput?
+
+}
+
+// MARK: - PlainOtpFieldModuleInput
+
+extension PlainOtpFieldPresenter: PlainOtpFieldModuleInput {
+}
+
+// MARK: - PlainOtpFieldViewOutput
+
+extension PlainOtpFieldPresenter: PlainOtpFieldViewOutput {
+
+    func viewLoaded() {
+        view?.setupInitialState()
+    }
+
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOTPField/PlainOTPFieldAdapter.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOTPField/PlainOTPFieldAdapter.swift
@@ -1,0 +1,47 @@
+//
+//  PlainOTPFieldAdapter.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+import UIKit
+import SFOTPTextField
+
+final class PlainOTPFieldAdapter: NSObject {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let numberOfPins = 6
+        static let pinSize = CGSize(width: 32, height: 32)
+        static let space: CGFloat = 0
+    }
+
+}
+
+// MARK: - OTPTextFieldData
+
+extension PlainOTPFieldAdapter: OTPTextFieldData {
+
+    public func numberOfPins() -> Int {
+        return Constants.numberOfPins
+    }
+
+    public func otpTextField(viewAt index: Int) -> PinContainer {
+        guard let pinView = PlainPinView.loadFromNib() as? PinContainer else {
+            fatalError("Can't find class for init pinField")
+        }
+        return pinView
+    }
+
+    public func otpTextField(sizeForViewAt index: Int) -> CGSize {
+        return Constants.pinSize
+    }
+
+    public func otpTextField(spaceForViewAt index: Int) -> CGFloat {
+        return Constants.space
+    }
+
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOTPField/PlainPinView/PlainPinView.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOTPField/PlainPinView/PlainPinView.swift
@@ -1,0 +1,115 @@
+//
+//  PlainPinView.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+import UIKit
+import SFOTPTextField
+
+final class PlainPinView: UIView {
+
+    // MARK: - IBOutlets
+
+    @IBOutlet private weak var codeLabel: UILabel!
+    @IBOutlet private weak var placeholderView: UIView!
+    @IBOutlet private weak var indicatorView: UIView!
+
+    // MARK: - UIView
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupInitialState()
+    }
+
+}
+
+// MARK: - PinContainer
+
+extension PlainPinView: PinContainer {
+
+    func set(value: String?) {
+        codeLabel.text = value
+        placeholderView.isHidden = true
+    }
+
+    func clear() {
+        codeLabel.text = nil
+        placeholderView.isHidden = false
+    }
+
+    func setupState(isActive: Bool, isError: Bool) {
+        if isActive && indicatorView.isHidden {
+            startIndicatorAnimation()
+        } else if !isActive {
+            stopIndicatorAnimation()
+        }
+        let color = isError ? Colors.Figma.defaultRed : Colors.Figma.negativeBackground
+        placeholderView.backgroundColor = color
+    }
+
+}
+
+// MARK: – Configuration
+
+private extension PlainPinView {
+
+    func setupInitialState() {
+        configureCodeLabel()
+        configureIndicatorView()
+        configurePlaceholderView()
+    }
+
+    func configureCodeLabel() {
+        codeLabel.text = nil
+        codeLabel.font = UIFont.systemFont(ofSize: 24, weight: .semibold)
+        codeLabel.textColor = Colors.Figma.defaultText
+    }
+
+    func configureIndicatorView() {
+        indicatorView.backgroundColor = Colors.Figma.defaultBlue
+        indicatorView.layer.cornerRadius = 1
+        indicatorView.isHidden = true
+    }
+
+    func configurePlaceholderView() {
+        placeholderView.backgroundColor = Colors.Figma.negativeBackground
+        placeholderView.layer.cornerRadius = placeholderView.bounds.height / 2
+    }
+
+}
+
+// MARK: - Animation
+
+private extension PlainPinView {
+
+    func startIndicatorAnimation() {
+        let appearAnimation = CABasicAnimation(keyPath: "opacity")
+        appearAnimation.fromValue = 0.0
+        appearAnimation.toValue = 1.0
+        appearAnimation.duration = 0.5
+        appearAnimation.timingFunction = CAMediaTimingFunction(name: .easeIn)
+
+        let disappearAnimation = CABasicAnimation(keyPath: "opacity")
+        disappearAnimation.fromValue = 1.0
+        disappearAnimation.toValue = 0.0
+        disappearAnimation.duration = 0.5
+        disappearAnimation.timingFunction = CAMediaTimingFunction(name: .easeIn)
+
+        let animationGroup = CAAnimationGroup()
+        animationGroup.animations = [appearAnimation, disappearAnimation]
+        animationGroup.duration = 1
+        animationGroup.repeatCount = .infinity
+
+        indicatorView.isHidden = false
+        indicatorView.layer.add(animationGroup, forKey: "fade")
+    }
+
+    func stopIndicatorAnimation() {
+        indicatorView.isHidden = true
+        indicatorView.layer.removeAllAnimations()
+    }
+
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOTPField/PlainPinView/PlainPinView.xib
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOTPField/PlainPinView/PlainPinView.xib
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="PlainPinView" customModule="OTPTextFieldExample" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b8U-kT-Doa">
+                    <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vMj-Mf-PPB">
+                    <rect key="frame" x="0.0" y="0.0" width="2" height="32"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="2" id="HIS-Ra-VGP"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bA8-d5-lpc">
+                    <rect key="frame" x="12" y="12" width="8" height="8"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="8" id="gkw-NV-Nkf"/>
+                        <constraint firstAttribute="height" constant="8" id="sXR-Aq-JTt"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="bA8-d5-lpc" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="BwR-t7-k7B"/>
+                <constraint firstAttribute="trailing" secondItem="b8U-kT-Doa" secondAttribute="trailing" id="LiK-K3-Olb"/>
+                <constraint firstItem="b8U-kT-Doa" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="OAN-BK-igx"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="b8U-kT-Doa" secondAttribute="bottom" id="ab3-5R-vJu"/>
+                <constraint firstItem="vMj-Mf-PPB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="bYi-gd-H8K"/>
+                <constraint firstAttribute="bottom" secondItem="vMj-Mf-PPB" secondAttribute="bottom" id="hOj-e2-gSx"/>
+                <constraint firstItem="bA8-d5-lpc" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="k90-Eq-Qul"/>
+                <constraint firstItem="b8U-kT-Doa" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="xti-HN-6rm"/>
+                <constraint firstItem="vMj-Mf-PPB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="zwC-8i-NEG"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="codeLabel" destination="b8U-kT-Doa" id="3wv-Tw-eYU"/>
+                <outlet property="indicatorView" destination="vMj-Mf-PPB" id="U63-2t-4Ro"/>
+                <outlet property="placeholderView" destination="bA8-d5-lpc" id="VV9-Hx-020"/>
+            </connections>
+            <point key="canvasLocation" x="133" y="129"/>
+        </view>
+    </objects>
+</document>

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewController.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewController.swift
@@ -1,0 +1,77 @@
+//
+//  PlainOtpFieldViewController.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+import UIKit
+import SFOTPTextField
+
+final class PlainOtpFieldViewController: UIViewController {
+
+    // MARK: - IBOutlets
+
+    @IBOutlet private weak var descriptionLabel: UILabel!
+    @IBOutlet private weak var otpField: OTPTextField!
+
+    // MARK: - Properties
+
+    var output: PlainOtpFieldViewOutput?
+
+    // MARK: - UIViewController
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        output?.viewLoaded()
+    }
+
+}
+
+// MARK: - PlainOtpFieldViewInput
+
+extension PlainOtpFieldViewController: PlainOtpFieldViewInput {
+
+    func setupInitialState() {
+        configureNavigationBar()
+        configureDescription()
+        configureOtpField()
+    }
+
+}
+
+// MARK: - Configuration
+
+private extension PlainOtpFieldViewController {
+
+    func configureNavigationBar() {
+        title = OTPFieldType.plain.title
+    }
+
+    func configureDescription() {
+        descriptionLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        descriptionLabel.textColor = Colors.Figma.defaultText
+        descriptionLabel.text = OTPFieldType.plain.description
+        descriptionLabel.numberOfLines = 0
+    }
+
+    func configureOtpField() {
+        let configuration = OTPFieldConfiguration(adapter: PlainOTPFieldAdapter())
+        otpField.setConfiguration(configuration)
+        otpField.onOTPEnter = { [weak self] otpCode in
+            guard otpCode != OTPFieldType.plain.password else {
+                return
+            }
+            self?.otpField.clear()
+            self?.otpField.setError()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                self?.otpField.removeError()
+            }
+        }
+        otpField.onTextChanged = { [weak self] code in
+            self?.otpField.removeError()
+        }
+    }
+
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewController.xib
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewController.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PlainOtpFieldViewController" customModule="OTPTextFieldExample" customModuleProvider="target">
+            <connections>
+                <outlet property="descriptionLabel" destination="Yet-N8-ZM5" id="TSO-Mw-aLc"/>
+                <outlet property="otpField" destination="k16-Gr-pdo" id="iHJ-M2-QkR"/>
+                <outlet property="view" destination="iN0-l3-epB" id="Q3p-Ee-1CD"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yet-N8-ZM5">
+                    <rect key="frame" x="16" y="24" width="288" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="k16-Gr-pdo" customClass="OTPTextField" customModule="SFOTPTextField">
+                    <rect key="frame" x="64" y="69" width="192" height="32"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="32" id="3Hp-Wh-R3k"/>
+                        <constraint firstAttribute="width" constant="192" id="exv-Vn-juQ"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="k16-Gr-pdo" firstAttribute="top" secondItem="Yet-N8-ZM5" secondAttribute="bottom" constant="24" id="OAo-X6-S4G"/>
+                <constraint firstItem="k16-Gr-pdo" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="VMy-m8-P0d"/>
+                <constraint firstItem="Yet-N8-ZM5" firstAttribute="top" secondItem="fZO-gv-KXM" secondAttribute="top" constant="24" id="bGS-ap-zNx"/>
+                <constraint firstItem="Yet-N8-ZM5" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="f17-AH-6Eh"/>
+                <constraint firstAttribute="trailing" secondItem="Yet-N8-ZM5" secondAttribute="trailing" constant="16" id="yjH-dj-iif"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fZO-gv-KXM"/>
+            <point key="canvasLocation" x="131" y="154"/>
+        </view>
+    </objects>
+</document>

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewInput.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewInput.swift
@@ -1,0 +1,12 @@
+//
+//  PlainOtpFieldViewInput.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+protocol PlainOtpFieldViewInput: class {
+    /// Method for setup initial state of view
+    func setupInitialState()
+}

--- a/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewOutput.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/PlainOtpField/View/PlainOtpFieldViewOutput.swift
@@ -1,0 +1,12 @@
+//
+//  PlainOtpFieldViewOutput.swift
+//  OTPTextFieldExample
+//
+//  Created by Александр Чаусов on 25/07/2020.
+//  Copyright © 2020 Fixique. All rights reserved.
+//
+
+protocol PlainOtpFieldViewOutput {
+    /// Notify presenter that view is ready
+    func viewLoaded()
+}

--- a/Example/OTPTextFieldExample/Flows/Main/RoundOtpField/View/RoundOtpFieldViewController.swift
+++ b/Example/OTPTextFieldExample/Flows/Main/RoundOtpField/View/RoundOtpFieldViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import OTPTextField
+import SFOTPTextField
 
 final class RoundOtpFieldViewController: UIViewController {
 

--- a/Example/OTPTextFieldExample/Flows/Main/RoundOtpField/View/RoundOtpFieldViewController.xib
+++ b/Example/OTPTextFieldExample/Flows/Main/RoundOtpField/View/RoundOtpFieldViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fce-IT-RZv" customClass="OTPTextField" customModule="OTPTextField">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fce-IT-RZv" customClass="OTPTextField" customModule="SFOTPTextField">
                     <rect key="frame" x="15" y="69" width="290" height="44"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>

--- a/Example/OTPTextFieldExample/Library/Enums/OTPFieldType.swift
+++ b/Example/OTPTextFieldExample/Library/Enums/OTPFieldType.swift
@@ -12,6 +12,7 @@ enum OTPFieldType: CaseIterable {
     case `default`
     case round
     case custom
+    case plain
 
     var title: String {
         switch self {
@@ -21,6 +22,8 @@ enum OTPFieldType: CaseIterable {
             return L10n.OTPFieldType.Round.title
         case .custom:
             return L10n.OTPFieldType.Custom.title
+        case .plain:
+            return L10n.OTPFieldType.Plain.title
         }
     }
 
@@ -32,6 +35,8 @@ enum OTPFieldType: CaseIterable {
             return L10n.OTPFieldType.Round.description(password)
         case .custom:
             return L10n.OTPFieldType.Custom.description(password)
+        case .plain:
+            return L10n.OTPFieldType.Plain.description(password)
         }
     }
 
@@ -43,6 +48,8 @@ enum OTPFieldType: CaseIterable {
             return "123456"
         case .custom:
             return "1234"
+        case .plain:
+            return "123456"
         }
     }
 }

--- a/Example/OTPTextFieldExample/Resources/Images/Assets.swift
+++ b/Example/OTPTextFieldExample/Resources/Images/Assets.swift
@@ -20,11 +20,11 @@
 internal enum Asset {
   internal enum Colors {
 
+    internal static let textColor = ColorAsset(name: "Colors/TextColor")
     internal static let background = ColorAsset(name: "Colors/background")
     internal static let contaienrBackground = ColorAsset(name: "Colors/contaienrBackground")
     internal static let defaultBlue = ColorAsset(name: "Colors/defaultBlue")
     internal static let red = ColorAsset(name: "Colors/red")
-    internal static let textColor = ColorAsset(name: "Colors/textColor")
   }
   internal static let iconArrowRight = ImageAsset(name: "icon-arrow-right")
   internal static let iconBackLeft = ImageAsset(name: "icon-back-left")

--- a/Example/OTPTextFieldExample/Resources/Strings/Localizable.strings
+++ b/Example/OTPTextFieldExample/Resources/Strings/Localizable.strings
@@ -8,10 +8,12 @@
 "OTPFieldType.Default.title" = "Default input field";
 "OTPFieldType.Round.title" = "Round input field";
 "OTPFieldType.Custom.title" = "Custom input field";
+"OTPFieldType.Plain.title" = "Plain input field";
 
 "OTPFieldType.Default.description" = "This is an example of a default input field. An error state has been added to it. Correct password is %@";
 "OTPFieldType.Round.description" = "This is an example of a default rounded input field. An error state has been added to it. Correct password is %@";
 "OTPFieldType.Custom.description" = "This is an example of a fully custom input field otp. An error state has been added to it. I create a custom pin view and adapter. Correct password is %@";
+"OTPFieldType.Plain.description" = "This is an example of a fully custom input field otp. Very similar to customOtpField. Has custom behavior, due to which the error is reset on its own after two seconds. Correct password is %@";
 
 // MARK: - Errors
 

--- a/Example/OTPTextFieldExample/Resources/Strings/Strings.swift
+++ b/Example/OTPTextFieldExample/Resources/Strings/Strings.swift
@@ -41,6 +41,14 @@ internal enum L10n {
       /// Default input field
       internal static let title = L10n.tr("Localizable", "OTPFieldType.Default.title")
     }
+    internal enum Plain {
+      /// This is an example of a fully custom input field otp. Very similar to customOtpField. Has custom behavior, due to which the error is reset on its own after two seconds. Correct password is %@
+      internal static func description(_ p1: String) -> String {
+        return L10n.tr("Localizable", "OTPFieldType.Plain.description", p1)
+      }
+      /// Plain input field
+      internal static let title = L10n.tr("Localizable", "OTPFieldType.Plain.title")
+    }
     internal enum Round {
       /// This is an example of a default rounded input field. An error state has been added to it. Correct password is %@
       internal static func description(_ p1: String) -> String {

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -9,7 +9,7 @@ def common_pods
   utils
   pod 'SurfUtils/XibView', :git => 'https://github.com/surfstudio/iOS-Utils.git', :tag => '10.0.5'
   pod 'ReactiveDataDisplayManager', :git => 'https://github.com/surfstudio/ReactiveDataDisplayManager', :commit => '73122a834e7e90744dd828804afb32dbd48a83c6'
-  pod 'OTPTextField', :path => '../'
+  pod 'SFOTPTextField', :path => '../'
 
 end
 

--- a/OTPTextField.xcodeproj/project.pbxproj
+++ b/OTPTextField.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ru.fixique.OTPTextField;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -640,7 +640,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ru.fixique.OTPTextField;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/OTPTextField/Library/Protocols/PinContainer.swift
+++ b/OTPTextField/Library/Protocols/PinContainer.swift
@@ -14,16 +14,20 @@ public protocol PinContainer: class {
     var view: UIView { get }
     /// Method for set character value for view
     func set(value: String?)
-    /// Method should implement error state
-    func setError()
-    /// Method should remove error state
-    func removeError()
     /// Remove characters from view
     func clear()
-    /// Method for animate view indicator
-    func animateIndicator()
-    /// Method will be remove indicator from current view before set characters
-    func removeIndicator()
+    /// Method for pin states update.
+    ///
+    /// Each pin has two states: active or inactive, error state or not.
+    /// When implementing a pin, everyone have to decide for himself:
+    /// what is more important - an error state or an active state?
+    /// Depending on the answer to this question, implement the display logic.
+    /// And in order not to store the state inside the view -
+    /// this method returns the current state of the object for both states.
+    /// - Parameters:
+    ///     - isActive: true if target pin is active, false if not
+    ///     - isError: true if all OTP-filed has error-state in this moment, false if not
+    func setupState(isActive: Bool, isError: Bool)
 }
 
 public extension PinContainer where Self: UIView {

--- a/OTPTextField/TextField/Default/PinViews/DefaultPinView/DefaultPinView.swift
+++ b/OTPTextField/TextField/Default/PinViews/DefaultPinView/DefaultPinView.swift
@@ -37,16 +37,12 @@ extension DefaultPinView: PinContainer {
         codeLabel.text = nil
     }
 
-    public func setError() {}
-
-    public func removeError() {}
-
-    public func animateIndicator() {
-        startIndicatorAnimation()
-    }
-
-    public func removeIndicator() {
-        stopIndicatorAnimation()
+    public func setupState(isActive: Bool, isError: Bool) {
+        if isActive && indicatorView.isHidden {
+            startIndicatorAnimation()
+        } else if !isActive {
+            stopIndicatorAnimation()
+        }
     }
 
 }

--- a/OTPTextField/TextField/Default/PinViews/RoundPinView/RoundPinView.swift
+++ b/OTPTextField/TextField/Default/PinViews/RoundPinView/RoundPinView.swift
@@ -45,20 +45,13 @@ extension RoundPinView: PinContainer {
         codeLabel.text = nil
     }
 
-    public func setError() {
-        outerContainerView.backgroundColor = Constants.errorColor
-    }
-
-    public func removeError() {
-        outerContainerView.backgroundColor = Constants.defaultColor
-    }
-
-    public func animateIndicator() {
-        setIndicatorActive()
-    }
-
-    public func removeIndicator() {
-        setIndicatorInactive()
+    public func setupState(isActive: Bool, isError: Bool) {
+        if isActive {
+            outerContainerView.backgroundColor = Constants.indicatorColor
+        } else {
+            let color = isError ? Constants.errorColor : Constants.defaultColor
+            outerContainerView.backgroundColor = color
+        }
     }
 
 }
@@ -87,20 +80,6 @@ private extension RoundPinView {
         codeLabel.font = UIFont.systemFont(ofSize: 14.0, weight: .regular)
         codeLabel.textAlignment = .center
         codeLabel.text = nil
-    }
-
-}
-
-// MARK: - Animation
-
-private extension RoundPinView {
-
-    func setIndicatorActive() {
-        outerContainerView.backgroundColor = Constants.indicatorColor
-    }
-
-    func setIndicatorInactive() {
-        outerContainerView.backgroundColor = Constants.defaultColor
     }
 
 }

--- a/SFOTPTextField.podspec
+++ b/SFOTPTextField.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SFOTPTextField"
-  s.version = "1.0.0"
+  s.version = "1.1.0"
   s.summary = "This library makes it easy to implement SMS input field with the ability to automatically substitute code from SMS messages"
   s.homepage = "https://github.com/fixique/OTPTextField"
   s.license = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
# Problem

in `OTOPTextField` in 163 lines have been next code:

```swift
pinViews.filter { $0.view != pinViews[safe: currentCharactersCount]?.view }.forEach { $0.removeError() }
```

this logic, that filters current active pin view, leads to the bug in my custom otp field: when i invoke `removeError` method - placeholder-dot in my field saved its states with red color for active pin

![IMG_C154169810A8-1](https://user-images.githubusercontent.com/8776643/88460342-3eb18080-cea4-11ea-8ff5-f6883bfe49bc.jpeg)

# Discuss

As a result of a short conversation with the creator of the library, i decided that:
* keeping state in pin-view - bad practice
* but adding a new parameter can complicate the current interface

# Solution

I replaced 4 methods for changing state with one. So for any change in the state of activity or error, this method will be called, and the view will be aware of both states - and based on this, it will be able to decide how to change the layout.

Also, i fixed builds in Example-project)